### PR TITLE
feat: add pet shop main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Shopping Mall React
 
-A minimal React front-end demonstrating features inspired by five well-known online shopping malls: Amazon, eBay, Walmart, Alibaba, and Rakuten.
+A minimal React front-end showing the main page of a fictional pet supplies store, **PawPals Pet Shop**.
 
 ## Getting started
 
-Open `index.html` in a web browser with internet access. The page uses CDN links to load React and renders a list of shopping malls with notable features.
+Open `index.html` in a web browser with internet access. The page uses CDN links to load React and renders a simple landing page with product categories and featured items for a pet shop.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -2,25 +2,36 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Shopping Mall Benchmark</title>
+    <title>PawPals Pet Shop</title>
     <style>
       body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
-      header { background: #222; color: #fff; padding: 1rem; text-align: center; }
-      .mall-list { display: flex; flex-wrap: wrap; justify-content: center; padding: 1rem; }
-      .mall-card {
+      .site-header { background: #ff6b6b; color: #fff; padding: 1rem; text-align: center; }
+      .hero { background: #ffeaa7; padding: 2rem 1rem; text-align: center; }
+      .categories { display: flex; flex-wrap: wrap; justify-content: center; padding: 1rem; }
+      .category-card {
         border: 1px solid #ccc;
         border-radius: 8px;
         margin: 0.5rem;
         padding: 1rem;
         width: 200px;
+        text-align: center;
         box-shadow: 2px 2px 6px rgba(0,0,0,0.1);
       }
-      .mall-card h2 { font-size: 1.2rem; margin-top: 0; }
-      .mall-card ul { padding-left: 1.2rem; }
+      .featured { padding: 1rem; }
+      .product-grid { display: flex; flex-wrap: wrap; justify-content: center; }
+      .product-card {
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        margin: 0.5rem;
+        padding: 1rem;
+        width: 150px;
+        text-align: center;
+        box-shadow: 2px 2px 6px rgba(0,0,0,0.1);
+      }
     </style>
   </head>
   <body>
-    <header><h1>Shopping Mall Benchmark</h1></header>
+    <header class="site-header"><h1>PawPals Pet Shop</h1></header>
     <div id="root"></div>
     <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>

--- a/src/App.js
+++ b/src/App.js
@@ -1,52 +1,69 @@
-const malls = [
-  {
-    name: "Amazon",
-    features: ["Massive product selection", "Prime shipping", "Personalized recommendations"],
-  },
-  {
-    name: "eBay",
-    features: ["Auction-style listings", "Buyer protection", "Global marketplace"],
-  },
-  {
-    name: "Walmart",
-    features: ["Everyday low prices", "Store pickup", "Grocery delivery"],
-  },
-  {
-    name: "Alibaba",
-    features: ["Wholesale pricing", "International trade", "Supplier directory"],
-  },
-  {
-    name: "Rakuten",
-    features: ["Cashback rewards", "Marketplace diversity", "Member points"],
-  },
+const categories = [
+  { name: "Food", description: "Healthy meals and snacks" },
+  { name: "Toys", description: "Fun for hours" },
+  { name: "Grooming", description: "Keep them looking great" },
+  { name: "Accessories", description: "Collars, leashes and more" },
 ];
 
-// Aggregate unique features from all benchmarked malls to inspire our own shop
-const myMall = {
-  name: "MyMall",
-  features: Array.from(new Set(malls.flatMap((m) => m.features))),
-};
+const featured = [
+  { name: "Chew Toy", price: "$9.99" },
+  { name: "Organic Dog Food", price: "$24.99" },
+  { name: "Cozy Bed", price: "$49.99" },
+];
 
-function ShoppingMall({ name, features }) {
+function Header() {
   return (
-    <div className="mall-card">
-      <h2>{name}</h2>
-      <ul>
-        {features.map((f, idx) => (
-          <li key={idx}>{f}</li>
+    <header className="site-header">
+      <h1>PawPals Pet Shop</h1>
+    </header>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="hero">
+      <h2>Everything Your Dog Needs</h2>
+      <p>Quality toys, tasty treats and comfy beds.</p>
+    </section>
+  );
+}
+
+function CategorySection() {
+  return (
+    <section className="categories">
+      {categories.map((cat) => (
+        <div className="category-card" key={cat.name}>
+          <h3>{cat.name}</h3>
+          <p>{cat.description}</p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function FeaturedProducts() {
+  return (
+    <section className="featured">
+      <h2>Featured Products</h2>
+      <div className="product-grid">
+        {featured.map((prod) => (
+          <div className="product-card" key={prod.name}>
+            <h4>{prod.name}</h4>
+            <span>{prod.price}</span>
+          </div>
         ))}
-      </ul>
-    </div>
+      </div>
+    </section>
   );
 }
 
 function App() {
   return (
-    <div className="mall-list">
-      {malls.map((mall) => (
-        <ShoppingMall key={mall.name} {...mall} />
-      ))}
-      <ShoppingMall key={myMall.name} {...myMall} />
+    <div>
+      <Header />
+      <Hero />
+      <CategorySection />
+      <FeaturedProducts />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace benchmarking layout with a pet supplies store landing page
- add hero, categories, and featured product sections
- update documentation and styles for PawPals Pet Shop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a65af5ec832687deba375ff20a93