### PR TITLE
feat: add sliding category carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,39 @@
         margin-bottom: 0.5rem;
       }
 
+      .category-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .more-btn {
+        background: none;
+        border: none;
+        color: #0074e9;
+        cursor: pointer;
+        font-size: 0.9rem;
+      }
+
+      .carousel-container {
+        overflow: hidden;
+      }
+
+      .carousel-track {
+        display: flex;
+        transition: transform 0.5s ease;
+      }
+
+      .slide {
+        display: flex;
+        min-width: 100%;
+        gap: 1rem;
+      }
+
+      .slide .product-card {
+        flex: 1;
+      }
+
     </style>
   </head>
   <body>

--- a/src/App.js
+++ b/src/App.js
@@ -21,46 +21,60 @@ function NavBar({ onNavigate }) {
   );
 }
 
-function CategoryCarousel({ title, items }) {
-  const [start, setStart] = React.useState(0);
+function CategoryCarousel({ title, items, onMore }) {
+  const slides = [];
+  for (let i = 0; i < items.length; i += 2) {
+    slides.push(items.slice(i, i + 2));
+  }
+  const [index, setIndex] = React.useState(0);
 
   React.useEffect(() => {
     const interval = setInterval(() => {
-      setStart((prev) => (prev + 5) % items.length);
+      setIndex((prev) => (prev + 1) % slides.length);
     }, 3000);
     return () => clearInterval(interval);
-  }, [items.length]);
-
-  const visibleItems = Array.from({ length: 5 }, (_, i) => items[(start + i) % items.length]);
+  }, [slides.length]);
 
   return (
     <section className="category-page">
-      <h2>{title}</h2>
-      <div className="product-grid">
-        {visibleItems.map((item) => (
-          <div className="product-card" key={item.id}>
-            <img src={item.image} alt={item.name} />
-            <h4>{item.name}</h4>
-          </div>
-        ))}
+      <div className="category-header">
+        <h2>{title}</h2>
+        <button className="more-btn" onClick={onMore}>더보기</button>
+      </div>
+      <div className="carousel-container">
+        <div
+          className="carousel-track"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {slides.map((slide, idx) => (
+            <div className="slide" key={idx}>
+              {slide.map((item) => (
+                <div className="product-card" key={item.id}>
+                  <img src={item.image} alt={item.name} />
+                  <h4>{item.name}</h4>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );
 }
 
-function Home() {
+function Home({ onNavigate }) {
   return (
     <div>
       <section className="hero">
         <h2>우리 반려동물을 위한 최고의 선택</h2>
         <p>필요한 모든 용품을 한 곳에서 만나보세요.</p>
       </section>
-      <CategoryCarousel title="목욕 용품" items={bathItems} />
-      <CategoryCarousel title="배변 용품" items={toiletItems} />
-      <CategoryCarousel title="산책 용품" items={walkItems} />
-      <CategoryCarousel title="놀이 용품" items={playItems} />
-      <CategoryCarousel title="간식" items={snackItems} />
-      <CategoryCarousel title="영양제" items={supplementItems} />
+      <CategoryCarousel title="목욕 용품" items={bathItems} onMore={() => onNavigate('bath')} />
+      <CategoryCarousel title="배변 용품" items={toiletItems} onMore={() => onNavigate('toilet')} />
+      <CategoryCarousel title="산책 용품" items={walkItems} onMore={() => onNavigate('walk')} />
+      <CategoryCarousel title="놀이 용품" items={playItems} onMore={() => onNavigate('play')} />
+      <CategoryCarousel title="간식" items={snackItems} onMore={() => onNavigate('snack')} />
+      <CategoryCarousel title="영양제" items={supplementItems} onMore={() => onNavigate('supplement')} />
     </div>
   );
 }
@@ -83,7 +97,7 @@ function App() {
       case 'supplement':
         return <SupplementPage onBack={() => setPage('home')} />;
       default:
-        return <Home />;
+        return <Home onNavigate={setPage} />;
     }
   };
 


### PR DESCRIPTION
## Summary
- show two products at a time per category and slide horizontally
- add 더보기 button to jump to category pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6e2f5f62083269863b240ccdaf014