### PR TITLE
Enable local build and import-map based React runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ A minimal React front-end showing the main page of a fictional pet supplies stor
 
 ## Getting started
 
-Open `index.html` in a web browser with internet access. The page uses CDN links to load React and renders a simple landing page with product categories and featured items for a pet shop.
+Install dependencies and build the TypeScript sources:
+
+```
+npm install
+npm run build
+```
+
+Open `index.html` in a web browser with internet access. The page uses an import map to load React from a CDN and renders a simple landing page with product categories and featured items for a pet shop.
 
 ## Development
 
-This project does not use a build step. React and Babel are loaded from public CDNs.
+TypeScript files in `src/` compile to ES modules in `dist/` via `npm run build`.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -186,6 +186,16 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/index.tsx"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@18",
+          "react-dom/client": "https://esm.sh/react-dom@18/client",
+          "react/jsx-runtime": "https://esm.sh/react@18/jsx-runtime",
+          "react/jsx-dev-runtime": "https://esm.sh/react@18/jsx-dev-runtime"
+        }
+      }
+    </script>
+    <script type="module" src="./dist/index.js"></script>
   </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "Node",
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": false,
+    "outDir": "dist"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- compile TypeScript sources into `dist/` for local use
- load React and ReactDOM via import maps and serve compiled modules
- document build and run instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e71591a48326baeefabee6fd813d